### PR TITLE
don't try to install a 'tests' package at top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     version=version,
     cmdclass=cmdclass,
     python_requires=">=3.7",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     maintainer="Bas Nijholt",
     maintainer_email="bas@nijho.lt",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     version=version,
     cmdclass=cmdclass,
     python_requires=">=3.7",
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     maintainer="Bas Nijholt",
     maintainer_email="bas@nijho.lt",


### PR DESCRIPTION
Hello Bas,

first, I hope you don't mind I included your component for [Home Assistant Gentoo Overlay](https://github.com/onkelbeh/HomeAssistantRepository). I do not use this component myself. But, during compilation test, the installation test script threw an error, because `setup.py` tries to install a package called `tests` at top level.

I currently patched this for now at my repo (https://github.com/onkelbeh/HomeAssistantRepository/blob/master/dev-python/aiokef/aiokef-0.2.16.ebuild).

This change adds a generic exclusion to `find_packages()`.

Thanks a lot.
 \B.