### PR TITLE
Recognise get_play_pause response 132 (stopped)

### DIFF
--- a/aiokef/aiokef.py
+++ b/aiokef/aiokef.py
@@ -503,6 +503,8 @@ class AsyncKefSpeaker:
             return "Paused"
         elif response == 129:
             return "Playing"
+        elif response == 132:
+            return "Stopped"
         else:
             raise ConnectionError(
                 f"Getting play or pause failed, got response {response}."


### PR DESCRIPTION
Hi all, submitting a small change I've made for my own projects - as far as I can tell code 132 corresponds to "stopped", or in other words, nothing playing.
Tested on my LSX running the latest firmware 5.1.
Thanks for your all your work on this project, cheers.
